### PR TITLE
27 initialiser un site statique

### DIFF
--- a/src/main/java/ch/heigvd/app/Init.java
+++ b/src/main/java/ch/heigvd/app/Init.java
@@ -1,0 +1,65 @@
+package ch.heigvd.app;
+
+import org.apache.commons.io.FileUtils;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.concurrent.Callable;
+
+@Command(name = "init")
+public class Init implements Callable<Integer> {
+    @CommandLine.Parameters(index = "0", description = "Path to init " +
+            "directory")
+    private String path;
+
+    @CommandLine.Option(names = {"-f", "--force"}, description = "Overwrite files")
+    private boolean overwrite;
+
+    @Override
+    public Integer call() throws Exception {
+
+        File myPath =
+                new File(System.getProperty("user" + ".dir") + "/" + path +
+                        "/");
+
+        System.out.println("Initializing: " + path);
+
+
+        Boolean exists = false;
+        if(!overwrite) {
+            File f = new File("config/");
+
+            // Populates the array with names of files and directories
+            String[] pathnames = f.list();
+
+            // check if files already exists in destination folder
+
+            for (String file : pathnames) {
+                File pathToFile = new File(myPath + "/" + file);
+                if (Files.exists(pathToFile.toPath())) {
+                    System.out.println("File \"" + file + "\" already exists");
+                    if (!exists) {
+                        exists = true;
+                    }
+                }
+            }
+
+            if (exists) {
+                System.out.println("Files already exists in destination folder. " +
+                        "If you want to overwrite them use :");
+                System.out.println("statique init <Path> --force>");
+            }
+        }
+
+        if(!exists || overwrite) {
+            File sourceDirectory = new File("config/");
+            File destinationDirectory = new File(myPath.toString());
+
+            FileUtils.copyDirectory(sourceDirectory, destinationDirectory);
+        }
+
+        return 0;
+    }
+}

--- a/src/main/java/ch/heigvd/app/Init.java
+++ b/src/main/java/ch/heigvd/app/Init.java
@@ -53,6 +53,7 @@ public class Init implements Callable<Integer> {
             }
         }
 
+        // copy config directory to init path
         if(!exists || overwrite) {
             File sourceDirectory = new File("config/");
             File destinationDirectory = new File(myPath.toString());

--- a/src/main/java/ch/heigvd/app/Main.java
+++ b/src/main/java/ch/heigvd/app/Main.java
@@ -10,7 +10,8 @@ import java.util.concurrent.Callable;
         mixinStandardHelpOptions = true,
         version = "static 0.1",
         description = "Generate random static websites",
-        subcommands = {New.class, Clean.class, Build.class, Serve.class})
+        subcommands = {New.class, Clean.class, Build.class, Serve.class,
+                Init.class})
 public class Main implements Callable<Integer>
 {
     @Override

--- a/src/test/java/ch/heigvd/app/MainTest.java
+++ b/src/test/java/ch/heigvd/app/MainTest.java
@@ -77,4 +77,44 @@ public class MainTest
             System.out.println(e.getMessage());
         }
     }
+
+    @Test
+    // Test that the init command init a directory with config files
+    public void statiqueInitShouldInitADirectory() {
+        // run the command
+        Main app = new Main();
+        StringWriter sw = new StringWriter();
+        CommandLine cmd = new CommandLine(app);
+        cmd.setOut(new PrintWriter(sw));
+
+        File path = new File("monTEST/siteTEST/");
+        File root = new File("monTEST/");
+
+        // check that the test directory doesn't exist
+        assertFalse("Test directory already exists",
+                Files.exists(root.toPath()));
+
+        int exitCode = cmd.execute("init", path.toString());
+        assertEquals(0, exitCode);
+
+        // check that config.json exists
+        // check that index.md exists
+
+        String dirName = "monTEST/siteTEST/";
+        String confFile = "config.json";
+        String indexFile = "index.md";
+
+        assertTrue(Files.exists(new File((dirName + confFile)).toPath()));
+        assertTrue(Files.exists(new File((dirName + indexFile)).toPath()));
+
+        // Delete the test directory
+        File pathToTestDir =
+                new File(System.getProperty("user" + ".dir") + "/monTEST");
+        try {
+            FileUtils.deleteDirectory(pathToTestDir);
+        }
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Add init features with --force or -f option.

Description:
The command
`statique init <path>`

init the <path> directory by copying the content of the config/ directory to "path". If files from config/ already exists in "path", the copy will be canceled and `statique init <path> --force` should be used to overwrite the files.

Should close #27 