### PR TITLE
75 publication du site dans un répertoire distant

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,11 @@
       <artifactId>handlebars</artifactId>
       <version>4.3.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <version>6.1.0.202203080745-r</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/ch/heigvd/app/Main.java
+++ b/src/main/java/ch/heigvd/app/Main.java
@@ -12,7 +12,7 @@ import picocli.CommandLine.IVersionProvider;
         mixinStandardHelpOptions = true,
         description = "Generate random static websites",
         subcommands = {New.class, Clean.class, Build.class, Serve.class,
-                Init.class},
+                Init.class, Publish.class},
         versionProvider = Main.ManifestVersionProvider.class)
 public class Main implements Callable<Integer>
 {

--- a/src/main/java/ch/heigvd/app/commands/Publish.java
+++ b/src/main/java/ch/heigvd/app/commands/Publish.java
@@ -1,0 +1,31 @@
+package ch.heigvd.app.commands;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.PushCommand;
+import org.eclipse.jgit.api.RemoteAddCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.RepositoryNotFoundException;
+import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import picocli.CommandLine.Command;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.Scanner;
+
+@Command(name = "publish")
+public class Publish implements Callable<Integer> {
+    private final static Logger LOGGER = Logger.getLogger(Publish.class.getName());
+
+    @Override
+    public Integer call() throws Exception {
+
+        
+
+        return 0;
+    }
+}

--- a/src/main/java/ch/heigvd/app/commands/Publish.java
+++ b/src/main/java/ch/heigvd/app/commands/Publish.java
@@ -11,11 +11,10 @@ import picocli.CommandLine.Command;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Scanner;
 import java.util.concurrent.Callable;
-
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.Scanner;
 
 @Command(name = "publish")
 public class Publish implements Callable<Integer> {
@@ -38,7 +37,7 @@ public class Publish implements Callable<Integer> {
         Git git = null;
         try {
             git = Git.open(localPath);
-            LOGGER.info("Already a Git repository: " + localPath);;
+            LOGGER.info("Already a Git repository: " + localPath);
         } catch (RepositoryNotFoundException e) {
             LOGGER.info("Initialising " + localPath + " as a git repository");
             try {
@@ -72,12 +71,7 @@ public class Publish implements Callable<Integer> {
 
         String token = scanner.nextLine();  // Read user input
 
-        // test values with a test account on github
-        //String token = "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";
-        //String token2 = "ghp_xr7bpujomx3bvqpuyfdr04pywfdfdb2unsx2";
-        //String httpUrl = "https://github.com/diltest/DIL-TEST.git";
-
-        if(git != null) {
+        if (git != null) {
             git.add().addFilepattern("./build/").call();
             LOGGER.log(Level.INFO, "Added build/ directory to stagging");
 
@@ -92,8 +86,7 @@ public class Publish implements Callable<Integer> {
 
             LOGGER.log(Level.INFO, "Push was successful");
             System.out.println("publish done");
-        }
-        else {
+        } else {
             LOGGER.log(Level.SEVERE, "Error: git variable null");
         }
 

--- a/src/main/java/ch/heigvd/app/commands/Publish.java
+++ b/src/main/java/ch/heigvd/app/commands/Publish.java
@@ -24,12 +24,12 @@ public class Publish implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
 
-        LOGGER.setLevel(Level.INFO);
+        LOGGER.setLevel(Level.WARNING);
         System.out.println("publishing config/ directory on GitHub");
 
         File localPath = new File(System.getProperty("user" + ".dir"));
 
-        System.out.println(localPath);
+        LOGGER.info(localPath.toString());
 
         Scanner scanner = new Scanner(System.in);  // Create a Scanner object
 
@@ -90,6 +90,7 @@ public class Publish implements Callable<Integer> {
         pushCommand.call();
 
         LOGGER.log(Level.INFO, "Push was successful");
+        System.out.println("publish done");
 
         return 0;
     }

--- a/src/main/java/ch/heigvd/app/commands/Publish.java
+++ b/src/main/java/ch/heigvd/app/commands/Publish.java
@@ -24,7 +24,72 @@ public class Publish implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
 
-        
+        LOGGER.setLevel(Level.INFO);
+        System.out.println("publishing config/ directory on GitHub");
+
+        File localPath = new File(System.getProperty("user" + ".dir"));
+
+        System.out.println(localPath);
+
+        Scanner scanner = new Scanner(System.in);  // Create a Scanner object
+
+        // Check if the current directory is a git repository. If not it
+        // initialize it.
+        Git git = null;
+        try {
+            git = Git.open(localPath);
+            LOGGER.info("Already a Git repository: " + localPath);;
+        } catch (RepositoryNotFoundException e) {
+            LOGGER.info("Initialising " + localPath + " as a git repository");
+            try {
+                git = Git.init().setDirectory(localPath).call();
+                LOGGER.log(Level.INFO, "Sucessfully initialized git " +
+                        "repository");
+
+                System.out.println("Enter the repository url: ");
+                String url = scanner.nextLine();  // Read user input
+                System.out.println("url: " + url);  // Output user input
+
+                // add remote repository
+                RemoteAddCommand remoteAddCommand = git.remoteAdd();
+                remoteAddCommand.setName("origin");
+
+                remoteAddCommand.setUri(new URIish(url));
+
+                remoteAddCommand.call();
+                LOGGER.log(Level.INFO, "Sucessfully set remote");
+            } catch (GitAPIException e1) {
+                e1.printStackTrace();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        // Ask the user to enter the remote git repository url and their
+        // GitHub Access token
+
+        System.out.println("Enter your GitHub access token: ");
+
+        String token = scanner.nextLine();  // Read user input
+
+        // test values with a test account on github
+        //String token = "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";
+        //String token2 = "ghp_xr7bpujomx3bvqpuyfdr04pywfdfdb2unsx2";
+        //String httpUrl = "https://github.com/diltest/DIL-TEST.git";
+
+        git.add().addFilepattern("./build/").call();
+        LOGGER.log(Level.INFO, "Added build/ directory to stagging");
+
+        git.commit().setMessage("static publish build directory").setSign(false).call();
+
+        // push to remote
+        PushCommand pushCommand = git.push();
+
+        pushCommand.setCredentialsProvider(new
+                UsernamePasswordCredentialsProvider(token, ""));
+        pushCommand.call();
+
+        LOGGER.log(Level.INFO, "Push was successful");
 
         return 0;
     }

--- a/src/main/java/ch/heigvd/app/commands/Publish.java
+++ b/src/main/java/ch/heigvd/app/commands/Publish.java
@@ -77,20 +77,25 @@ public class Publish implements Callable<Integer> {
         //String token2 = "ghp_xr7bpujomx3bvqpuyfdr04pywfdfdb2unsx2";
         //String httpUrl = "https://github.com/diltest/DIL-TEST.git";
 
-        git.add().addFilepattern("./build/").call();
-        LOGGER.log(Level.INFO, "Added build/ directory to stagging");
+        if(git != null) {
+            git.add().addFilepattern("./build/").call();
+            LOGGER.log(Level.INFO, "Added build/ directory to stagging");
 
-        git.commit().setMessage("static publish build directory").setSign(false).call();
+            git.commit().setMessage("static publish build directory").setSign(false).call();
 
-        // push to remote
-        PushCommand pushCommand = git.push();
+            // push to remote
+            PushCommand pushCommand = git.push();
 
-        pushCommand.setCredentialsProvider(new
-                UsernamePasswordCredentialsProvider(token, ""));
-        pushCommand.call();
+            pushCommand.setCredentialsProvider(new
+                    UsernamePasswordCredentialsProvider(token, ""));
+            pushCommand.call();
 
-        LOGGER.log(Level.INFO, "Push was successful");
-        System.out.println("publish done");
+            LOGGER.log(Level.INFO, "Push was successful");
+            System.out.println("publish done");
+        }
+        else {
+            LOGGER.log(Level.SEVERE, "Error: git variable null");
+        }
 
         return 0;
     }


### PR DESCRIPTION
Git integration to publish the build directory on remote repos.

Command: static publish
Constraints for this first version: tested only with GitHub repos and access tokens. Testing was done in a separate git repository and not on this project's git to avoid conflicts.

This command will check if the current folder is a git repository. If not, it will initialize it and the user will be asked to enter the remote url and their GitHub access token. The "build/" folder will then be added and commited and then pushed.

No automated test was done for this part as it seems complicated and unpractical.

Further improvement that could be done :

- hide access token when entered by user
- add SSH authentification
- add the ability to sign commits. Signing is currently set to false

closes #75 #76 